### PR TITLE
Fix search copy comment typo

### DIFF
--- a/src/components/SearchComponent.vue
+++ b/src/components/SearchComponent.vue
@@ -58,7 +58,7 @@ export default {
 
         // searchMovie() {
         //     // store.params = { ...this.search };
-        //     //facciamo una copia di this.earch per non cancellarne le proprietà
+        //     //facciamo una copia di this.search per non cancellarne le proprietà
         //     const search = { ...this.search }
         //     //cicliamo sull'array delle chiavi dell'oggetto e se il valore è vuoto cancelliamo la proprietà
         //     Object.keys(search).forEach((val) => {


### PR DESCRIPTION
## Summary
- fix minor typo in SearchComponent comments referencing `this.search`

## Testing
- `npx --version`

------
https://chatgpt.com/codex/tasks/task_e_687278a83ae083208e25ba4db1bc8964