### PR TITLE
Improve loader and transitions

### DIFF
--- a/src/assets/general.scss
+++ b/src/assets/general.scss
@@ -10,7 +10,7 @@ $fa-font-path: "./webfonts";
 
 body {
   padding-top: 100px;
-  background: #141414;
+  background: $color-background;
   overflow-x: hidden;
   // background: radial-gradient(
   //   circle,
@@ -20,7 +20,7 @@ body {
 }
 * {
   scrollbar-width: auto;
-  scrollbar-color: #821010 #ffffff00;
+  scrollbar-color: $color-scrollbar-thumb #ffffff00;
 }
 
 /* Chrome, Edge, and Safari */
@@ -29,11 +29,11 @@ body {
 }
 
 *::-webkit-scrollbar-track {
-  background: rgba($color: #212121, $alpha: 0.8);
+  background: rgba($color-scrollbar-track, 0.8);
 }
 
 *::-webkit-scrollbar-thumb {
-  background-color: #800101;
+  background-color: $color-scrollbar-thumb;
   border-radius: 10px;
   border: 3px solid #ffffff00;
 }

--- a/src/assets/partials/_mixins.scss
+++ b/src/assets/partials/_mixins.scss
@@ -1,0 +1,16 @@
+@use 'variables' as *;
+
+@mixin transition($property, $duration: $transition-normal, $ease: ease-in-out) {
+  transition: #{$property} #{$duration} #{$ease};
+}
+
+@mixin skeleton {
+  background: linear-gradient(90deg, $color-skeleton-base 25%, $color-skeleton-highlight 50%, $color-skeleton-base 75%);
+  background-size: 200% 100%;
+  animation: skeleton-loading 1.2s infinite ease-in-out;
+}
+
+@keyframes skeleton-loading {
+  0% { background-position: 200% 0; }
+  100% { background-position: -200% 0; }
+}

--- a/src/assets/partials/_variables.scss
+++ b/src/assets/partials/_variables.scss
@@ -1,0 +1,13 @@
+// Color palette
+$color-primary: #ff0000;
+$color-background: #141414;
+$color-scrollbar-thumb: #800101;
+$color-scrollbar-track: #212121;
+$color-text: whitesmoke;
+$color-skeleton-base: #202020;
+$color-skeleton-highlight: #2c2c2c;
+
+// Timing variables
+$transition-fast: 0.25s;
+$transition-normal: 0.5s;
+$transition-slow: 0.8s;

--- a/src/components/CardComponent.vue
+++ b/src/components/CardComponent.vue
@@ -137,37 +137,32 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use '../assets/partials/mixins' as *;
+@use '../assets/partials/variables' as *;
+
 .mycard {
-    // padding: 1rem;
-    background-color: #141414;
-    color: whitesmoke;
+    background-color: $color-background;
+    color: $color-text;
     height: 350px;
     overflow: hidden;
-    // border-radius: 10px;
-    transition: all 0.5s;
-    // transition-delay: 1s;
     cursor: pointer;
+    transform-origin: top center;
+    @include transition(transform, $transition-normal);
 
     h4 {
         // padding: 0.5rem 0;
     }
 
     h4~div {
-        color: #ffffff;
+        color: $color-text;
     }
 
     &:hover {
-
-        transform: scale(130%);
+        transform: scale(1.3);
         width: 280px;
-        // height: 350px;
         border: 1px solid gray;
         border-radius: 10px;
-        // margin: 40px 0;
         box-shadow: 0px 0px 15px 5px black;
-
-        // width: 300px;
-        // height: 600px;
         z-index: 1000;
     }
 
@@ -200,7 +195,7 @@ img {
     height: 350px;
     object-fit: cover;
     object-position: top;
-    transition: all 0.5s;
+    @include transition(all, $transition-normal);
     // transition-delay: 1s;
 }
 
@@ -218,10 +213,10 @@ img {
     // top: 0;
     // left: 50%;
     // transform: translate(-50%, -50%);
-    background-color: rgba($color: #202020, $alpha: 0.8);
+    background-color: rgba($color-background, 0.8);
     // top: 175px;
     opacity: 0;
-    transition: opacity 0.5s;
+    @include transition(opacity, $transition-normal);
     // transition-delay: 1s;
     // transition-delay: 1s;
 
@@ -241,7 +236,7 @@ img {
 /* Firefox */
 * {
     scrollbar-width: auto;
-    scrollbar-color: #a81010 #ffffff00;
+    scrollbar-color: $color-scrollbar-thumb #ffffff00;
 }
 
 /* Chrome, Edge, and Safari */
@@ -250,11 +245,11 @@ img {
 }
 
 *::-webkit-scrollbar-track {
-    background: rgba($color: #212121, $alpha: 0.3);
+    background: rgba($color-scrollbar-track, 0.3);
 }
 
 *::-webkit-scrollbar-thumb {
-    background-color: #800101;
+    background-color: $color-scrollbar-thumb;
     border-radius: 10px;
     border: 3px solid #ffffff00;
 }
@@ -270,7 +265,7 @@ img {
 
 .v-enter-active,
 .v-leave-active {
-    transition: opacity 0.5s ease-out;
+    @include transition(opacity, $transition-normal, ease-out);
 }
 
 .v-enter-from,

--- a/src/components/ListComponent.vue
+++ b/src/components/ListComponent.vue
@@ -1,8 +1,9 @@
 <template>
-
-    <div class="bg-loading" v-if="store.loading">
-        <div class="ring">Loading
-            <span></span>
+    <div v-if="store.loading" class="container py-3">
+        <div class="row row-cols-1 row-cols-md-4 row-cols-lg-5 g-3 py-1">
+            <div v-for="n in 10" :key="n" class="col">
+                <div class="skeleton-card"></div>
+            </div>
         </div>
     </div>
     <Transition name="slide-fade">
@@ -45,6 +46,7 @@ export default {
 </script>
 
 <style lang="scss" scoped>
+@use '../assets/partials/mixins' as *;
 @use '../assets/partials/variables' as *;
 
 h2 {
@@ -67,92 +69,19 @@ h2 {
 
 
 
-.ring {
-    position: absolute;
-    top: 50%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    width: 150px;
-    height: 150px;
-    background: transparent;
-    border: 3px solid #3c3c3c;
-    border-radius: 50%;
-    text-align: center;
-    line-height: 147px;
-    font-family: sans-serif;
-    font-size: 20px;
-    color: #ff0000;
-    letter-spacing: 4px;
-    text-transform: uppercase;
-    text-shadow: 0 0 10px #000000;
-    box-shadow: 0 0 20px rgba(0, 0, 0, .5);
-}
 
-.ring:before {
-    // content: '';
-    position: absolute;
-    top: -3px;
-    left: -3px;
-    width: 100%;
-    height: 100%;
-    border: 3px solid transparent;
-    border-top: 3px solid #ff0000;
-    border-right: 3px solid #ff0000;
-    border-radius: 50%;
-    animation: animateC 2s linear infinite;
-}
-
-span {
-
-    display: block;
-    position: absolute;
-    top: calc(50% - 2px);
-    left: 50%;
-    width: 50%;
-    height: 4px;
-    background: transparent;
-    transform-origin: left;
-    animation: animate 2s linear infinite;
-}
-
-span:before {
-    content: '';
-    position: absolute;
-    width: 16px;
-    height: 16px;
-    border-radius: 50%;
-    background: #ff0000;
-    top: -6px;
-    right: -8px;
-    box-shadow: 0 0 20px #ff0000;
-}
-
-@keyframes animateC {
-    0% {
-        transform: rotate(0deg);
-    }
-
-    100% {
-        transform: rotate(360deg);
-    }
-}
-
-@keyframes animate {
-    0% {
-        transform: rotate(45deg);
-    }
-
-    100% {
-        transform: rotate(405deg);
-    }
+.skeleton-card {
+    height: 350px;
+    border-radius: 10px;
+    @include skeleton;
 }
 
 .slide-fade-enter-active {
-    transition: all 0.8s ease-out;
+    @include transition(all, $transition-slow, ease-out);
 }
 
 .slide-fade-leave-active {
-    transition: all 0.8s cubic-bezier(1, 0.5, 0.8, 1);
+    @include transition(all, $transition-slow, cubic-bezier(1, 0.5, 0.8, 1));
 }
 
 .slide-fade-enter-from,


### PR DESCRIPTION
## Summary
- add SCSS variables and mixins for colors and timing
- replace list loader with skeleton cards
- improve card hover transitions using mixins
- update global styles to use variables

## Testing
- `npm install`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68727c38fbc083208fdc18661da9f476