### PR TITLE
Fix trending API path

### DIFF
--- a/src/store.js
+++ b/src/store.js
@@ -76,7 +76,7 @@ export const store = reactive({
   getPopular() {
     this.loading = true;
     axios
-      .get(this.apiURL + "/trending/movie/week" + this.key_ath, {
+      .get(this.apiURL + "trending/movie/week" + this.key_ath, {
         params: {
           language: "it-IT",
         },


### PR DESCRIPTION
## Summary
- remove extra slash when querying trending items

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6872873693d88320b9805d2a1844887a