### PR TITLE
Adjust transition timing

### DIFF
--- a/src/assets/partials/_variables.scss
+++ b/src/assets/partials/_variables.scss
@@ -9,5 +9,5 @@ $color-skeleton-highlight: #2c2c2c;
 
 // Timing variables
 $transition-fast: 0.25s;
-$transition-normal: 0.5s;
+$transition-normal: 0.3s;
 $transition-slow: 0.8s;


### PR DESCRIPTION
## Summary
- shorten the default animation time by setting `$transition-normal` to 0.3s

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872cb0589e883209c68b8800040a516