### PR TITLE
Implement scroll snapping

### DIFF
--- a/src/components/CardComponent.vue
+++ b/src/components/CardComponent.vue
@@ -142,6 +142,7 @@ export default {
     height: 350px;
     width: 200px;
     overflow: hidden;
+    scroll-snap-align: start;
     cursor: pointer;
     transform-origin: top center;
     @include transition(all, $transition-normal);

--- a/src/components/ListComponent.vue
+++ b/src/components/ListComponent.vue
@@ -78,6 +78,8 @@ h2 {
     display: flex;
     flex-wrap: nowrap;
     overflow-x: auto;
+    scroll-behavior: smooth;
+    scroll-snap-type: x mandatory;
     gap: 1rem;
     padding-bottom: 0.5rem;
     scrollbar-width: none; /* Firefox */


### PR DESCRIPTION
## Summary
- enable smooth horizontal scrolling for card lists
- snap cards to start within scroll containers

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6872cfe41a9883208d4663229ec60070